### PR TITLE
feat: staking proxy for local controller chain

### DIFF
--- a/contracts/WooStakingController.sol
+++ b/contracts/WooStakingController.sol
@@ -42,7 +42,7 @@ import {TransferHelper} from "./util/TransferHelper.sol";
 
 contract WooStakingController is NonblockingLzApp, BaseAdminOperation {
     event StakeOnController(address indexed user, uint256 amount);
-    event WithdrawOnController(address indexed user, uint256 amount);
+    event UnstakeOnController(address indexed user, uint256 amount);
     event CompoundOnController(address indexed user);
 
     uint8 public constant ACTION_STAKE = 1;
@@ -88,7 +88,7 @@ contract WooStakingController is NonblockingLzApp, BaseAdminOperation {
     function _unstake(address _user, uint256 _amount) private {
         balances[_user] -= _amount;
         stakingManager.unstakeWoo(_user, _amount);
-        emit WithdrawOnController(_user, _amount);
+        emit UnstakeOnController(_user, _amount);
     }
 
     function _compound(address _user) private {

--- a/contracts/WooStakingLocal.sol
+++ b/contracts/WooStakingLocal.sol
@@ -51,8 +51,8 @@ contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuar
     mapping(address => uint256) public balances;
 
     constructor(address _want, address _stakingManager) {
-        require(_want != address(0), "WooStakingLocal: invalid staking token address");
-        require(_stakingManager != address(0), "WooStakingLocal: invalid staking manager");
+        require(_want != address(0), "WooStakingLocal: !_want");
+        require(_stakingManager != address(0), "WooStakingLocal: !_stakingManager");
 
         want = IERC20(_want);
         stakingManager = IWooStakingManager(_stakingManager);
@@ -83,7 +83,7 @@ contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuar
     }
 
     function _unstake(address _user, uint256 _amount) private {
-        require(balances[_user] >= _amount, "WooStakingProxy: !BALANCE");
+        require(balances[_user] >= _amount, "WooStakingLocal: !BALANCE");
         balances[_user] -= _amount;
         TransferHelper.safeTransfer(address(want), _user, _amount);
         emit UnstakeOnLocal(_user, _amount);

--- a/contracts/WooStakingLocal.sol
+++ b/contracts/WooStakingLocal.sol
@@ -56,8 +56,6 @@ contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuar
 
         want = IERC20(_want);
         stakingManager = IWooStakingManager(_stakingManager);
-
-        // NOTE: set stakingLocal as the admin of stakingManager
     }
 
     function stake(uint256 _amount) external whenNotPaused nonReentrant {
@@ -97,6 +95,6 @@ contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuar
 
     function setStakingManager(address _stakingManager) external onlyAdmin {
         stakingManager = IWooStakingManager(_stakingManager);
-        // Don't forget to set stakingLocal as the admin of stakingManager
+        // NOTE: don't forget to set stakingLocal as the admin of stakingManager
     }
 }

--- a/contracts/WooStakingLocal.sol
+++ b/contracts/WooStakingLocal.sol
@@ -34,77 +34,69 @@ pragma solidity ^0.8.4;
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-import {NonblockingLzApp} from "@layerzerolabs/solidity-examples/contracts/lzApp/NonblockingLzApp.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IERC20, SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+import {IWooStakingLocal} from "./interfaces/IWooStakingLocal.sol";
 import {IWooStakingManager} from "./interfaces/IWooStakingManager.sol";
 import {BaseAdminOperation} from "./BaseAdminOperation.sol";
 import {TransferHelper} from "./util/TransferHelper.sol";
 
-contract WooStakingController is NonblockingLzApp, BaseAdminOperation {
-    event StakeOnController(address indexed user, uint256 amount);
-    event WithdrawOnController(address indexed user, uint256 amount);
-    event CompoundOnController(address indexed user);
-
-    uint8 public constant ACTION_STAKE = 1;
-    uint8 public constant ACTION_UNSTAKE = 2;
-    uint8 public constant ACTION_COMPOUND = 3;
+contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuard {
+    using SafeERC20 for IERC20;
 
     IWooStakingManager public stakingManager;
+    IERC20 public immutable want;
 
     mapping(address => uint256) public balances;
 
-    constructor(address _endpoint, address _stakingManager) NonblockingLzApp(_endpoint) {
+    constructor(address _want, address _stakingManager) {
+        require(_want != address(0), "WooStakingLocal: invalid staking token address");
+        require(_stakingManager != address(0), "WooStakingLocal: invalid staking manager");
+
+        want = IERC20(_want);
         stakingManager = IWooStakingManager(_stakingManager);
+
+        // NOTE: set stakingLocal as the admin of stakingManager
     }
 
-    // --------------------- LZ Receive Message Functions --------------------- //
-
-    function _nonblockingLzReceive(
-        uint16, // _srcChainId
-        bytes memory, // _srcAddress
-        uint64, // _nonce
-        bytes memory _payload
-    ) internal override whenNotPaused {
-        (address user, uint8 action, uint256 amount) = abi.decode(_payload, (address, uint8, uint256));
-        if (action == ACTION_STAKE) {
-            _stake(user, amount);
-        } else if (action == ACTION_UNSTAKE) {
-            _unstake(user, amount);
-        } else if (action == ACTION_COMPOUND) {
-            _compound(user);
-        } else {
-            revert("WooStakingController: !action");
-        }
+    function stake(uint256 _amount) external whenNotPaused nonReentrant {
+        _stake(msg.sender, _amount);
     }
 
-    // --------------------- Business Logic Functions --------------------- //
+    function stake(address _user, uint256 _amount) external whenNotPaused nonReentrant {
+        _stake(_user, _amount);
+    }
 
     function _stake(address _user, uint256 _amount) private {
-        stakingManager.stakeWoo(_user, _amount);
+        want.safeTransferFrom(msg.sender, address(this), _amount);
         balances[_user] += _amount;
-        emit StakeOnController(_user, _amount);
+        emit StakeOnProxy(_user, _amount);
+
+        stakingManager.stakeWoo(_user, _amount);
+    }
+
+    function unstake(uint256 _amount) external whenNotPaused nonReentrant {
+        _unstake(msg.sender, _amount);
+    }
+
+    function unstakeAll() external whenNotPaused nonReentrant {
+        _unstake(msg.sender, balances[msg.sender]);
     }
 
     function _unstake(address _user, uint256 _amount) private {
+        require(balances[_user] >= _amount, "WooStakingProxy: !BALANCE");
         balances[_user] -= _amount;
-        stakingManager.unstakeWoo(_user, _amount);
-        emit WithdrawOnController(_user, _amount);
-    }
+        TransferHelper.safeTransfer(address(want), _user, _amount);
+        emit WithdrawOnProxy(_user, _amount);
 
-    function _compound(address _user) private {
-        stakingManager.compoundAll(_user);
-        emit CompoundOnController(_user);
+        stakingManager.unstakeWoo(_user, _amount);
     }
 
     // --------------------- Admin Functions --------------------- //
 
-    function setStakingManager(address _manager) external onlyAdmin {
-        stakingManager = IWooStakingManager(_manager);
+    function setStakingManager(address _stakingManager) external onlyAdmin {
+        stakingManager = IWooStakingManager(_stakingManager);
+        // Don't forget to set stakingLocal as the admin of stakingManager
     }
-
-    function syncBalance(address _user, uint256 _balance) external onlyAdmin {
-        // TODO: handle the balance and reward update
-    }
-
-    receive() external payable {}
 }

--- a/contracts/WooStakingLocal.sol
+++ b/contracts/WooStakingLocal.sol
@@ -69,7 +69,7 @@ contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuar
     function _stake(address _user, uint256 _amount) private {
         want.safeTransferFrom(msg.sender, address(this), _amount);
         balances[_user] += _amount;
-        emit StakeOnProxy(_user, _amount);
+        emit StakeOnLocal(_user, _amount);
 
         stakingManager.stakeWoo(_user, _amount);
     }
@@ -86,7 +86,7 @@ contract WooStakingLocal is IWooStakingLocal, BaseAdminOperation, ReentrancyGuar
         require(balances[_user] >= _amount, "WooStakingProxy: !BALANCE");
         balances[_user] -= _amount;
         TransferHelper.safeTransfer(address(want), _user, _amount);
-        emit WithdrawOnProxy(_user, _amount);
+        emit UnstakeOnLocal(_user, _amount);
 
         stakingManager.unstakeWoo(_user, _amount);
     }

--- a/contracts/WooStakingManager.sol
+++ b/contracts/WooStakingManager.sol
@@ -65,10 +65,8 @@ contract WooStakingManager is IWooStakingManager, BaseAdminOperation, Reentrancy
 
     IWooStakingCompounder public compounder;
 
-    constructor(address _woo, address _wooPP, address _stakingLocal) {
+    constructor(address _woo) {
         woo = _woo;
-        wooPP = IWooPPV2(_wooPP);
-        stakingLocal = IWooStakingLocal(_stakingLocal);
     }
 
     modifier onlyMpRewarder() {
@@ -283,13 +281,19 @@ contract WooStakingManager is IWooStakingManager, BaseAdminOperation, Reentrancy
 
     // --------------------- Admin Functions --------------------- //
 
-    function setWooPP(address _wooPP) external onlyAdmin {
+    function setWooPP(address _wooPP) external onlyOwner {
         wooPP = IWooPPV2(_wooPP);
         emit SetWooPPOnStakingManager(_wooPP);
     }
 
-    function setStakingLocal(address _local) external onlyAdmin {
+    function setStakingLocal(address _local) external onlyOwner {
+        // remove the former local from `admin` if needed
+        if (address(stakingLocal) != address(0)) {
+            setAdmin(address(stakingLocal), false);
+        }
+
         stakingLocal = IWooStakingLocal(_local);
+        setAdmin(_local, true);
         emit SetStakingLocalOnStakingManager(_local);
     }
 

--- a/contracts/WooStakingManager.sol
+++ b/contracts/WooStakingManager.sol
@@ -286,15 +286,15 @@ contract WooStakingManager is IWooStakingManager, BaseAdminOperation, Reentrancy
         emit SetWooPPOnStakingManager(_wooPP);
     }
 
-    function setStakingLocal(address _local) external onlyOwner {
+    function setStakingLocal(address _stakingLocal) external onlyOwner {
         // remove the former local from `admin` if needed
         if (address(stakingLocal) != address(0)) {
             setAdmin(address(stakingLocal), false);
         }
 
-        stakingLocal = IWooStakingLocal(_local);
-        setAdmin(_local, true);
-        emit SetStakingLocalOnStakingManager(_local);
+        stakingLocal = IWooStakingLocal(_stakingLocal);
+        setAdmin(_stakingLocal, true);
+        emit SetStakingLocalOnStakingManager(_stakingLocal);
     }
 
     function setCompounder(address _compounder) external onlyAdmin {

--- a/contracts/WooStakingProxy.sol
+++ b/contracts/WooStakingProxy.sol
@@ -62,8 +62,8 @@ contract WooStakingProxy is IWooStakingProxy, NonblockingLzApp, BaseAdminOperati
         address _controller,
         address _want
     ) NonblockingLzApp(_endpoint) {
-        require(_controller != address(0), "WooStakingProxy: invalid controller address");
-        require(_want != address(0), "WooStakingProxy: invalid staking token address");
+        require(_controller != address(0), "WooStakingProxy: !_controller");
+        require(_want != address(0), "WooStakingProxy: !_want");
 
         controllerChainId = _controllerChainId;
         controller = _controller;
@@ -108,7 +108,7 @@ contract WooStakingProxy is IWooStakingProxy, NonblockingLzApp, BaseAdminOperati
         require(balances[user] >= _amount, "WooStakingProxy: !BALANCE");
         balances[user] -= _amount;
         want.safeTransfer(user, _amount);
-        emit WithdrawOnProxy(user, _amount);
+        emit UnstakeOnProxy(user, _amount);
         _sendMessage(user, ACTION_UNSTAKE, _amount);
     }
 
@@ -121,7 +121,7 @@ contract WooStakingProxy is IWooStakingProxy, NonblockingLzApp, BaseAdminOperati
     // --------------------- LZ Related Functions --------------------- //
 
     function _sendMessage(address user, uint8 _action, uint256 _amount) internal {
-        require(msg.value > 0, "WooStakingProxy: msg.value is 0");
+        require(msg.value > 0, "WooStakingProxy: !msg.value");
 
         bytes memory payload = abi.encode(user, _action, _amount);
         bytes memory adapterParams = abi.encodePacked(uint16(2), actionToDstGas[_action], uint256(0), address(0x0));

--- a/contracts/interfaces/IWooStakingLocal.sol
+++ b/contracts/interfaces/IWooStakingLocal.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IWooStakingLocal {
+    /* ----- Events ----- */
+
+    event StakeOnProxy(address indexed user, uint256 amount);
+
+    event WithdrawOnProxy(address indexed user, uint256 amount);
+
+    event CompoundOnProxy(address indexed user);
+
+    /* ----- State Variables ----- */
+
+    function want() external view returns (IERC20);
+
+    function balances(address user) external view returns (uint256 balance);
+
+    /* ----- Functions ----- */
+
+    function stake(uint256 _amount) external;
+
+    function stake(address _user, uint256 _amount) external;
+
+    function unstake(uint256 _amount) external;
+
+    function unstakeAll() external;
+}

--- a/contracts/interfaces/IWooStakingLocal.sol
+++ b/contracts/interfaces/IWooStakingLocal.sol
@@ -7,11 +7,8 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 interface IWooStakingLocal {
     /* ----- Events ----- */
 
-    event StakeOnProxy(address indexed user, uint256 amount);
-
-    event WithdrawOnProxy(address indexed user, uint256 amount);
-
-    event CompoundOnProxy(address indexed user);
+    event StakeOnLocal(address indexed user, uint256 amount);
+    event UnstakeOnLocal(address indexed user, uint256 amount);
 
     /* ----- State Variables ----- */
 

--- a/contracts/interfaces/IWooStakingManager.sol
+++ b/contracts/interfaces/IWooStakingManager.sol
@@ -13,7 +13,7 @@ interface IWooStakingManager {
     event CompoundAllOnStakingManager(address indexed user);
     event SetMPRewarderOnStakingManager(address indexed rewarder);
     event SetWooPPOnStakingManager(address indexed wooPP);
-    event SetStakingProxyOnStakingManager(address indexed stakingProxy);
+    event SetStakingLocalOnStakingManager(address indexed stakingProxy);
     event AddRewarderOnStakingManager(address indexed rewarder);
     event RemoveRewarderOnStakingManager(address indexed rewarder);
     event ClaimRewardsOnStakingManager(address indexed user);
@@ -40,9 +40,9 @@ interface IWooStakingManager {
 
     function addMP(address _user, uint256 _amount) external;
 
-    function compoundRewards(address _user) external payable;
+    function compoundRewards(address _user) external;
 
-    function compoundAll(address _user) external payable;
+    function compoundAll(address _user) external;
 
     function pendingRewards(
         address _user

--- a/contracts/interfaces/IWooStakingProxy.sol
+++ b/contracts/interfaces/IWooStakingProxy.sol
@@ -9,7 +9,7 @@ interface IWooStakingProxy {
 
     event StakeOnProxy(address indexed user, uint256 amount);
 
-    event WithdrawOnProxy(address indexed user, uint256 amount);
+    event UnstakeOnProxy(address indexed user, uint256 amount);
 
     event CompoundOnProxy(address indexed user);
 

--- a/contracts/test/TestStakingManager.sol
+++ b/contracts/test/TestStakingManager.sol
@@ -53,9 +53,9 @@ contract TestStakingManager is IWooStakingManager, BaseAdminOperation {
         mpTotalBalance += _amount;
     }
 
-    function compoundRewards(address _user) external payable {}
+    function compoundRewards(address _user) external {}
 
-    function compoundAll(address _user) external payable {}
+    function compoundAll(address _user) external {}
 
     function pendingRewards(address _user) external view returns (
         uint256 mpRewardAmount, address[] memory rewardTokens, uint256[] memory amounts

--- a/test/typescript/WooStakingLocal.test.ts
+++ b/test/typescript/WooStakingLocal.test.ts
@@ -1,0 +1,148 @@
+/*
+░██╗░░░░░░░██╗░█████╗░░█████╗░░░░░░░███████╗██╗
+░██║░░██╗░░██║██╔══██╗██╔══██╗░░░░░░██╔════╝██║
+░╚██╗████╗██╔╝██║░░██║██║░░██║█████╗█████╗░░██║
+░░████╔═████║░██║░░██║██║░░██║╚════╝██╔══╝░░██║
+░░╚██╔╝░╚██╔╝░╚█████╔╝╚█████╔╝░░░░░░██║░░░░░██║
+░░░╚═╝░░░╚═╝░░░╚════╝░░╚════╝░░░░░░░╚═╝░░░░░╚═╝
+*
+* MIT License
+* ===========
+*
+* Copyright (c) 2020 WooTrade
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+import { expect, util } from "chai";
+import { BigNumber, Contract, utils, Wallet } from 'ethers'
+import { ethers } from "hardhat";
+import { deployContract, deployMockContract } from "ethereum-waffle";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+const { mine, time, mineUpTo } = require("@nomicfoundation/hardhat-network-helpers");
+
+import { MpRewarder, SimpleRewarder, WooStakingManager, RewardBooster, WooStakingLocal } from "../../typechain";
+import MpRewarderArtifact from "../../artifacts/contracts/rewarders/MpRewarder.sol/MpRewarder.json";
+import WooStakingManagerArtifact from "../../artifacts/contracts/WooStakingManager.sol/WooStakingManager.json";
+import WooStakingLocalArtifact from "../../artifacts/contracts/WooStakingLocal.sol/WooStakingLocal.json";
+import TestTokenArtifact from "../../artifacts/contracts/test/TestToken.sol/TestToken.json";
+import TestStakingManagerArtifact from "../../artifacts/contracts/test/TestStakingManager.sol/TestStakingManager.json";
+import RewardBoosterArtifact from "../../artifacts/contracts/rewarders/RewardBooster.sol/RewardBooster.json";
+import IWooStakingCompounder from "../../artifacts/contracts/interfaces/IWooStakingCompounder.sol/IWooStakingCompounder.json";
+
+
+describe("WooStakingLocal tests", () => {
+
+    let owner: SignerWithAddress;
+    let baseToken: SignerWithAddress;
+
+    let mpRewarder: MpRewarder;
+    let booster: RewardBooster;
+    let compounder: Contract;
+    let stakingManager: WooStakingManager;
+    let stakingLocal: WooStakingLocal;
+    let user: SignerWithAddress;
+    let user1: SignerWithAddress;
+    let user2: SignerWithAddress;
+
+    let mpToken: Contract;
+    let wooToken: Contract;
+
+    before(async () => {
+        [owner] = await ethers.getSigners();
+
+        stakingManager = (await deployContract(owner, TestStakingManagerArtifact, [])) as WooStakingManager;
+        mpToken = await deployContract(owner, TestTokenArtifact, []);
+        await mpToken.mint(owner.address, utils.parseEther("100000"));
+
+        compounder = await deployMockContract(owner, IWooStakingCompounder.abi);
+        await compounder.mock.contains.returns(true);
+
+        mpRewarder = (await deployContract(owner, MpRewarderArtifact, [mpToken.address, stakingManager.address])) as MpRewarder;
+        await mpToken.mint(mpRewarder.address, utils.parseEther("100000"));
+        booster = (await deployContract(owner, RewardBoosterArtifact, [mpRewarder.address, compounder.address])) as RewardBooster;
+        await mpRewarder.setBooster(booster.address);
+        await stakingManager.setMPRewarder(mpRewarder.address);
+
+        wooToken = await deployContract(owner, TestTokenArtifact, []);
+        await wooToken.mint(owner.address, utils.parseEther("100000"));
+    });
+
+    beforeEach(async () => {
+        [user, user1, user2] = await ethers.getSigners();
+
+        await wooToken.mint(user.address, utils.parseEther("100000"));
+        await wooToken.mint(user1.address, utils.parseEther("100000"));
+        await wooToken.mint(user2.address, utils.parseEther("100000"));
+
+        stakingLocal = (await deployContract(
+            owner,
+            WooStakingLocalArtifact,
+            [wooToken.address, stakingManager.address])) as WooStakingLocal;
+    });
+
+    it("Staking local tests", async () => {
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(0);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(0);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(0);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(0);
+
+        await wooToken.approve(stakingLocal.address, 1000);
+        await stakingLocal["stake(uint256)"](100);  // why not error ?
+
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(100);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(100);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(0);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(0);
+
+        await stakingLocal["stake(address,uint256)"](user1.address, 500);  // why not error ?
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(100);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(100);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(500);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(500);
+    });
+
+    it("Unstaking local tests", async () => {
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(0);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(0);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(100);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(500);
+
+        await wooToken.approve(stakingLocal.address, 1000);
+        await stakingLocal["stake(uint256)"](100);  // why not error ?
+        await stakingLocal["stake(address,uint256)"](user1.address, 500);  // why not error ?
+
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(100);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(100 + 100);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(500);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(500 + 500);
+
+        await stakingLocal.unstake(50);
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(50);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(50 + 100);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(500);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(500 + 500);
+
+        await stakingLocal.connect(user1.address).unstakeAll();
+        expect(await stakingLocal.balances(owner.address)).to.be.equal(50);
+        expect(await stakingManager.wooBalance(owner.address)).to.be.equal(50 + 100);
+        expect(await stakingLocal.balances(user1.address)).to.be.equal(0);
+        expect(await stakingManager.wooBalance(user1.address)).to.be.equal(0 + 500);
+    });
+
+});


### PR DESCRIPTION
On controller, the staking of woo can directly call stakingManager's stakeWoo method. No need to send cross-chain messages via LZ.